### PR TITLE
Fix player by index allowed id range selection

### DIFF
--- a/revoice/src/revoice_player.cpp
+++ b/revoice/src/revoice_player.cpp
@@ -128,8 +128,8 @@ void Revoice_Update_Hltv(const char *pszNewValue)
 
 CRevoicePlayer *GetPlayerByIndex(const size_t clientId)
 {
-	if (clientId < 1 || clientId >= g_RehldsSvs->GetMaxClients() - 1) {
-		util_syserror("Invalid player edict id=%d\n", clientId);
+	if (clientId < 1 || clientId > g_RehldsSvs->GetMaxClients()) {
+		util_syserror("Invalid player index id=%d\n", clientId);
 	}
 
 	return &g_Players[ clientId - 1];


### PR DESCRIPTION
Player indexes should be in range from 1 to "max allowed players on server"
"max allowed players on server" is probably returned g_RehldsSvs->GetMaxClients()
So in case when for example g_RehldsSvs->GetMaxClients() is 26 server creshed on 25 player connected with message:

L 06/12/2021 - 20:55:07: [REVOICE]: ERROR: Invalid player edict id=25

because

clientId >= g_RehldsSvs->GetMaxClients() - 1

is

25 >= 26 - 1

This should fix that problem and now player ids should be validated properly